### PR TITLE
Cross-reference entities

### DIFF
--- a/index.html
+++ b/index.html
@@ -33,13 +33,27 @@
             <li>A <strong>domain</strong>: <a href="entity.html?d=41381">Ubiquitous Web</a>
                 <code class="url">entity.html?d=41381</code> </li>
             <li>A <strong>group</strong>: <a href="entity.html?g=68239">Data on the Web Best Practices Working Group</a>
-                <code class="url">entity.html?g=68239</code></li>
+                <code class="url">entity.html?g=68239</code>
+                <ul>
+                    <li>A <strong>charter</strong>: <a href="entity.html?g=46300&amp;c=155">Web and TV Interest Group, 2011/02/07&ndash;2013/02/28</a>
+                        <code class="url">entity.html?g=46300&amp;c=155</code></li>
+                </ul>
+            </li>
             <li>A <strong>specification</strong>: <a href="entity.html?s=dwbp">Data on the Web Best Practices</a>
-                <code class="url">entity.html?s=dwbp</code></li>
+                <code class="url">entity.html?s=dwbp</code>
+                <ul>
+                    <li>A <strong>version</strong>: <a href="entity.html?s=2dcontext&amp;v=20110525">HTML Canvas 2D Context, 2011-05-25</a>
+                        <code class="url">entity.html?s=2dcontext&amp;v=20110525</code></li>
+                </ul>
+            </li>
             <li>A <strong>user</strong>: <a href="entity.html?u=ggdj8tciu9kwwc4o4ww888ggkwok0c8">Ian Jacobs</a>
                 <code class="url">entity.html?u=ggdj8tciu9kwwc4o4ww888ggkwok0c8</code></li>
             <li>A <strong>service</strong>: <a href="entity.html?x=1913"><code>w3.org/2013/dwbp/track</code></a>
                 <code class="url">entity.html?x=1913</code></li>
+            <li>A <strong>participation</strong>: <a href="entity.html?p=1503">Deutsche Telekom AG</a>
+                <code class="url">entity.html?p=1503</code></li>
+            <li>An <strong>affiliation</strong>: <a href="entity.html?a=52794">W3C staff</a>
+                <code class="url">entity.html?a=52794</code></li>
         </ul>
 
     </body>

--- a/w3capi.js
+++ b/w3capi.js
@@ -221,13 +221,30 @@ exports.specification = idStep(SpecificationCtx, "specifications");
 function UserCtx (ctx) {
     Ctx.call(this, ctx);
 }
-subSteps(UserCtx, ["affiliations", "groups", "specifications"]);
+subSteps(UserCtx, ["affiliations", "groups", "participations", "specifications"]);
 
 // w3c.user("ivpki36ou94oo08osswccs80gcwogwk").fetch()
 // w3c.user("ivpki36ou94oo08osswccs80gcwogwk").affiliations().fetch()
 // w3c.user("ivpki36ou94oo08osswccs80gcwogwk").groups().fetch()
 // w3c.user("ivpki36ou94oo08osswccs80gcwogwk").specifications().fetch()
 exports.user = idStep(UserCtx, "users");
+
+// Affiliations:
+
+exports.affiliations = rootList('affiliations');
+function AffiliationCtx (ctx) {
+    Ctx.call(this, ctx);
+}
+subSteps(AffiliationCtx, ['participants', 'participations']);
+exports.affiliation = idStep(AffiliationCtx, 'affiliations');
+
+// Participations:
+
+function ParticipationCtx (ctx) {
+    Ctx.call(this, ctx);
+}
+subSteps(ParticipationCtx, ['participants']);
+exports.participation = idStep(ParticipationCtx, 'participations');
 
 },{"async":2,"superagent":7,"util":9}],2:[function(require,module,exports){
 (function (process,global){


### PR DESCRIPTION
Fixes #2.

While at it:
* Add 4 new entities (*charters*, *versions*, *participations*, *affiliations*), and set up most of their respective fields.
* Fix how certain types of items are rendered on lists.
* Update index page with examples of the new entities.

NB: this PR uses the browserified version of `node-w3capi` [from the `extend-entities` branch](https://github.com/w3c/node-w3capi/blob/tripu/extend-entities/lib/w3capi.js), which adds support for some new entities, needed here.