### PR TITLE
Show as many fields as possible for each entity

### DIFF
--- a/index.html
+++ b/index.html
@@ -33,13 +33,27 @@
             <li>A <strong>domain</strong>: <a href="entity.html?d=41381">Ubiquitous Web</a>
                 <code class="url">entity.html?d=41381</code> </li>
             <li>A <strong>group</strong>: <a href="entity.html?g=68239">Data on the Web Best Practices Working Group</a>
-                <code class="url">entity.html?g=68239</code></li>
+                <code class="url">entity.html?g=68239</code>
+                <ul>
+                    <li>A <strong>charter</strong>: <a href="entity.html?g=46300&amp;c=155">Web and TV Interest Group, 2011/02/07&ndash;2013/02/28</a>
+                        <code class="url">entity.html?g=46300&amp;c=155</code></li>
+                </ul>
+            </li>
             <li>A <strong>specification</strong>: <a href="entity.html?s=dwbp">Data on the Web Best Practices</a>
-                <code class="url">entity.html?s=dwbp</code></li>
+                <code class="url">entity.html?s=dwbp</code>
+                <ul>
+                    <li>A <strong>version</strong>: <a href="entity.html?s=2dcontext&amp;v=20110525">HTML Canvas 2D Context, 2011-05-25</a>
+                        <code class="url">entity.html?s=2dcontext&amp;v=20110525</code></li>
+                </ul>
+            </li>
             <li>A <strong>user</strong>: <a href="entity.html?u=ggdj8tciu9kwwc4o4ww888ggkwok0c8">Ian Jacobs</a>
                 <code class="url">entity.html?u=ggdj8tciu9kwwc4o4ww888ggkwok0c8</code></li>
             <li>A <strong>service</strong>: <a href="entity.html?x=1913"><code>w3.org/2013/dwbp/track</code></a>
                 <code class="url">entity.html?x=1913</code></li>
+            <li>A <strong>participation</strong>: <a href="entity.html?p=1503">Deutsche Telekom AG</a>
+                <code class="url">entity.html?p=1503</code></li>
+            <li>An <strong>affiliation</strong>: <a href="entity.html?a=52794">W3C staff</a>
+                <code class="url">entity.html?a=52794</code></li>
         </ul>
 
     </body>

--- a/style.css
+++ b/style.css
@@ -80,6 +80,19 @@ article h2 {
     text-transform: capitalize;
 }
 
+section.fields {
+    padding: 1em 2em;
+    background-color: #f0f0f0;
+}
+
+section.fields strong {
+    text-transform: capitalize;
+}
+
+section.fields p {
+    margin: 0;
+}
+
 footer {
     clear: both;
 }
@@ -94,4 +107,12 @@ footer {
 
 html.js .temp {
     visibility: visible;
+}
+
+span.yes {
+    color: #00c000;
+}
+
+span.no {
+    color: #c00000;
 }

--- a/w3capi.js
+++ b/w3capi.js
@@ -221,13 +221,30 @@ exports.specification = idStep(SpecificationCtx, "specifications");
 function UserCtx (ctx) {
     Ctx.call(this, ctx);
 }
-subSteps(UserCtx, ["affiliations", "groups", "specifications"]);
+subSteps(UserCtx, ["affiliations", "groups", "participations", "specifications"]);
 
 // w3c.user("ivpki36ou94oo08osswccs80gcwogwk").fetch()
 // w3c.user("ivpki36ou94oo08osswccs80gcwogwk").affiliations().fetch()
 // w3c.user("ivpki36ou94oo08osswccs80gcwogwk").groups().fetch()
 // w3c.user("ivpki36ou94oo08osswccs80gcwogwk").specifications().fetch()
 exports.user = idStep(UserCtx, "users");
+
+// Affiliations:
+
+exports.affiliations = rootList('affiliations');
+function AffiliationCtx (ctx) {
+    Ctx.call(this, ctx);
+}
+subSteps(AffiliationCtx, ['participants', 'participations']);
+exports.affiliation = idStep(AffiliationCtx, 'affiliations');
+
+// Participations:
+
+function ParticipationCtx (ctx) {
+    Ctx.call(this, ctx);
+}
+subSteps(ParticipationCtx, ['participants']);
+exports.participation = idStep(ParticipationCtx, 'participations');
 
 },{"async":2,"superagent":7,"util":9}],2:[function(require,module,exports){
 (function (process,global){


### PR DESCRIPTION
For each one of the 9 types of entities, show at the top a section with as much scalar info as we get from the API about that entity: dates, URLs, descriptions, flags, etc.

NB: this PR branches out from [branch `fix-11`](https://github.com/w3c/Unitas/tree/tripu/fix-11). I recommend merging #17 first, and then review this one.

![image](https://cloud.githubusercontent.com/assets/1016538/14099663/67867282-f5c2-11e5-8edf-e6c5fb7b2475.png)

![image](https://cloud.githubusercontent.com/assets/1016538/14099671/7dadfbf2-f5c2-11e5-87dd-aee4ab542332.png)

![image](https://cloud.githubusercontent.com/assets/1016538/14099678/8b4310b8-f5c2-11e5-9cef-c670a7b435af.png)

![image](https://cloud.githubusercontent.com/assets/1016538/14099689/a76ffc6a-f5c2-11e5-8348-146309dded17.png)