### PR TITLE
Refresh scrollspy after the DOM is modified

### DIFF
--- a/behaviour.js
+++ b/behaviour.js
@@ -152,6 +152,7 @@ const init = function(api) {
             attachHandlers();
             window.setTimeout(function() {
                 body.addClass('loaded');
+                body.scrollspy('refresh');
             }, 500);
         }
     };
@@ -464,8 +465,8 @@ requirejs.config({
     paths: {
         w3capi: 'https://w3c.github.io/node-w3capi/lib/w3capi',
         // @TODO: switch to minified jQuery in production:
-        // jquery: 'https://code.jquery.com/jquery-2.2.3.min',
-        jquery: 'https://code.jquery.com/jquery-2.2.3',
+        // jquery: 'https://code.jquery.com/jquery-2.2.4.min',
+        jquery: 'https://code.jquery.com/jquery-2.2.4',
         // @TODO: switch to minified Bootstrap JS in production:
         // bootstrap: 'https://maxcdn.bootstrapcdn.com/bootstrap/3.3.6/js/bootstrap.min',
         bootstrap: 'https://maxcdn.bootstrapcdn.com/bootstrap/3.3.6/js/bootstrap',


### PR DESCRIPTION
Fix #37.

While at it, update jQuery to 2.2.4 (can't go to 3.0.0 because scrollspy doesn't like it).