### PR TITLE
Second (and last, for now) batch of updates to adapt to current API signature

### DIFF
--- a/LICENSE.md
+++ b/LICENSE.md
@@ -1,6 +1,6 @@
 # The MIT License (MIT)
 
-Copyright &copy; 2016 [World Wide Web Consortium](https://www.w3.org/).
+Copyright &copy; 2016&ndash;2017 [World Wide Web Consortium](https://www.w3.org/).
 
 Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the &ldquo;software&rdquo;),
 to deal in the software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell

--- a/README.md
+++ b/README.md
@@ -1,31 +1,31 @@
 # Unitas
 
-Prototypes for the &ldquo;dynamic pages&rdquo; project.
+Prototypes for the &ldquo;dynamic pages&rdquo; project
 
 ## Examples
 
-<!-- ### Root view
+### &ldquo;Root&rdquo; view
 
-* With no arguments (or with *wrong* arguments): [`/`](https://w3c.github.io/Unitas/) -->
+With no arguments (or with *wrong* arguments): [`/`](https://w3c.github.io/Unitas/)
 
 ### Lists of entities that are &ldquo;listable&rdquo;
 
-* All domains: [`/?d=all`](https://w3c.github.io/Unitas/?d=all)
-* All groups: [`/?g=all`](https://w3c.github.io/Unitas/?g=all)
-* All specs: [`/?s=all`](https://w3c.github.io/Unitas/?s=all)
-* All affiliations: [`/?a=all`](https://w3c.github.io/Unitas/?a=all)
+1. All functions: [`/?f=all`](https://w3c.github.io/Unitas/?f=all)
+1. All groups: [`/?g=all`](https://w3c.github.io/Unitas/?g=all)
+1. All specs: [`/?s=all`](https://w3c.github.io/Unitas/?s=all)
+1. All affiliations: [`/?a=all`](https://w3c.github.io/Unitas/?a=all)
 
 ### Examples of particular Entities
 
-* A domain: [`/?d=41381`](https://w3c.github.io/Unitas/?d=41381)
-* A group: [`/?g=68239`](https://w3c.github.io/Unitas/?g=68239)
-* A charter: [`/?g=46300&c=155`](https://w3c.github.io/Unitas/?g=46300&c=155)
-* A spec: [`/?s=dwbp`](https://w3c.github.io/Unitas/?s=dwbp)
-* A version: [`/?s=2dcontext&v=20110525`](https://w3c.github.io/Unitas/?s=2dcontext&v=20110525)
-* A user: [`/?u=ggdj8tciu9kwwc4o4ww888ggkwok0c8`](https://w3c.github.io/Unitas/?u=ggdj8tciu9kwwc4o4ww888ggkwok0c8)
-* A service: [`/?x=1913`](https://w3c.github.io/Unitas/?x=1913)
-* A participation: [`/?p=1503`](https://w3c.github.io/Unitas/?p=1503)
-* An affiliation: [`/?a=52794`](https://w3c.github.io/Unitas/?a=52794)
+1. A function: [`/?f=109`](https://w3c.github.io/Unitas/?f=109)
+1. A group: [`/?g=68239`](https://w3c.github.io/Unitas/?g=68239)
+1. A charter: [`/?g=46300&c=155`](https://w3c.github.io/Unitas/?g=46300&c=155)
+1. A spec: [`/?s=dwbp`](https://w3c.github.io/Unitas/?s=dwbp)
+1. A version: [`/?s=2dcontext&v=20110525`](https://w3c.github.io/Unitas/?s=2dcontext&v=20110525)
+1. A user: [`/?u=ggdj8tciu9kwwc4o4ww888ggkwok0c8`](https://w3c.github.io/Unitas/?u=ggdj8tciu9kwwc4o4ww888ggkwok0c8)
+1. A service: [`/?x=1913`](https://w3c.github.io/Unitas/?x=1913)
+1. A participation: [`/?p=1503`](https://w3c.github.io/Unitas/?p=1503)
+1. An affiliation: [`/?a=52794`](https://w3c.github.io/Unitas/?a=52794)
 
 ## Contributing
 
@@ -76,6 +76,6 @@ In production, resources will be concatenated and loaded in parallel, and minifi
 
 ## Credits
 
-Copyright &copy; 2016 [World Wide Web Consortium](https://www.w3.org/).
+Copyright &copy; 2016&ndash;2017 [World Wide Web Consortium](https://www.w3.org/).
 
 This project is licensed [under the terms of the MIT license](LICENSE.md).

--- a/index.html
+++ b/index.html
@@ -178,7 +178,7 @@
 
             <div class="row">
                 <div class="col-xs-12">
-                    <p>Copyright &copy; 2016 <abbr title="World Wide Web Consortium">W3C</abbr>.</p>
+                    <p>Copyright &copy; 2016&ndash;2017 <abbr title="World Wide Web Consortium">W3C</abbr>.</p>
                 </div>
             </div>
 

--- a/style.css
+++ b/style.css
@@ -321,13 +321,17 @@ h3,
     box-shadow: 0 4px 4px #808080;
 }
 
+#about,
+#details,
 #dashboard,
+li a[href='#about'],
+li a[href='#details'],
 li a[href='#dashboard'] {
     display: none;
 }
 
 .suffix {
-    opacity: .6667;
+    opacity: .5;
 }
 
 /************************************** Images */

--- a/utils.js
+++ b/utils.js
@@ -51,11 +51,11 @@ var abbreviateGroupName = function(name) {
 
 var normaliseURI = function(uri) {
 
-    var result = uri.trim().toLowerCase();
+    var result = uri.trim(); // .toLowerCase();
     var matches = REGEX_URI.exec(result);
 
-    if (matches && matches.length > 2) {
-        result = matches[2];
+    if (matches && matches.length > 3) {
+        result = matches[3];
     }
 
     return result;
@@ -84,9 +84,9 @@ var getUrlVars = function() {
 
 var processURL = function() {
     var params = getUrlVars();
-    if(params.d) {
-        type = TYPE_DOMAIN;
-        id = ('all' !== params.d) ? params.d : undefined;
+    if(params.f) {
+        type = TYPE_FUNCTION;
+        id = ('all' !== params.f) ? params.f : undefined;
     } else if(params.c) {
         if (params.g) {
             type = TYPE_CHARTER;
@@ -146,7 +146,7 @@ var buildIndex = function() {
  */
 
 var buildLink = function(href, type) {
-    var REGEX_DOMAIN = /\/domains\/(\d+)$/i,
+    var REGEX_FUNCTION = /\/functions\/(\d+)$/i,
         REGEX_GROUP = /\/groups\/(\d+)$/i,
         REGEX_CHARTER = /\/groups\/(\d+)\/charters\/(\d+)$/i,
         REGEX_SPEC = /\/specifications\/([^\/]+)$/i,
@@ -155,8 +155,8 @@ var buildLink = function(href, type) {
         REGEX_SERVICE = /\/services\/(\d+)$/i,
         REGEX_PARTICIPATIONS = /\/participations\/(\d+)$/i,
         REGEX_AFFILIATIONS = /\/affiliations\/(\d+)$/i;
-    var match = REGEX_DOMAIN.exec(href);
-    if (match && match.length > 1) return '?d=' + match[1];
+    var match = REGEX_FUNCTION.exec(href);
+    if (match && match.length > 1) return '?f=' + match[1];
     match = REGEX_GROUP.exec(href);
     if (match && match.length > 1) return '?g=' + match[1];
     if ('group' === type) return `?g=${href}`;
@@ -191,4 +191,13 @@ var getDateFromURL = function(href) {
         return `${date.getDate()} ${MONTHS[date.getMonth()]} ${date.getFullYear()}`;
     } else
         return undefined;
+};
+
+/**
+ * @TODO
+ */
+
+var showSection = function(section) {
+    $(`#${section}`).show();
+    $(`li a[href="#${section}"]`).css('display', 'block');
 };


### PR DESCRIPTION
* Deprecate *domains* in favour of *functions* (fixes #55).
* Enable a &ldquo;root view&rdquo; (`/`), a kind of simple home page with a few links that serves as an entry point, and also to be shown when parameter are incorrect.
* Improve the way some types of items are displayed (recognise more kinds of services, better URIs, etc).
* Now, every section on the page (*about*, *details*, *dashboard*) is displayed only if it contains data (and ditto about its corresponding link on the navigation bar at the top).
* Update version (minor number).
* Update copyright notice in HTML page, README and licence file.

---

NB: this is a PR on top of the branch `tripu/general-update`, *not* on top of the default branch. I suspect it's better to merge this one *first*.